### PR TITLE
Sh/bcloud 8979

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+RelayTestApp/Scripts/Ids.cs

--- a/RelayTestApp/README.md
+++ b/RelayTestApp/README.md
@@ -5,3 +5,5 @@ This example demonstrates brainCloud's Matchmaking and Relay services.
 It is a simple "game" in which players can view each other's mouse movement and clicks via Relay messages.
 
 It's also cross-platform! Check out the web-based version here: [React RelayTestApp](http://ec2-18-219-26-183.us-east-2.compute.amazonaws.com:3004/)
+
+Enter your App ID and App Secret in the `Scripts/Ids.cs` file to run the project.

--- a/RelayTestApp/Scripts/Ids.cs
+++ b/RelayTestApp/Scripts/Ids.cs
@@ -1,0 +1,8 @@
+public static class Ids 
+{
+	// brainCloud data
+	public static string _url = "https://api.braincloudservers.com/dispatcherv2";
+	public static string _appSecret = "00000000-0000-0000-0000-000000000000";
+	public static string _appID = "00000";
+	public static string _version = "1.0.0";
+}

--- a/RelayTestApp/Scripts/Main.cs
+++ b/RelayTestApp/Scripts/Main.cs
@@ -60,10 +60,6 @@ public partial class Main : Node
 	private bool _userWasPresentSinceStart = false;
 
 	// brainCloud data
-	private string _url = "https://api.braincloudservers.com/dispatcherv2";
-	private string _appSecret = "";
-	private string _appID = "";
-	private string _version = "1.0.0";
 	private BrainCloudWrapper _brainCloudWrapper;
 
 	public override void _Ready()
@@ -111,7 +107,7 @@ public partial class Main : Node
 		
 		// Initialize brainCloud
 		_brainCloudWrapper = new BrainCloudWrapper();
-		_brainCloudWrapper.Init(_url, _appSecret, _appID, _version);
+		_brainCloudWrapper.Init(Ids._url, Ids._appSecret, Ids._appID, Ids._version);
 
 		if (!_brainCloudWrapper.Client.Initialized)
 		{


### PR DESCRIPTION
Moving the app secret away from the main file.
Main.cs is likely to have modifications whenever the project is worked on, and is therefore likely to be pushed. This change puts the app secret in Ids.cs, which is in the gitignore. This ensures the app secret will never be pushed. 